### PR TITLE
fix: resolved Game Over screen and score/lives UI overlap on Level 2

### DIFF
--- a/Assets/Settings/Build Profiles/Itch.asset
+++ b/Assets/Settings/Build Profiles/Itch.asset
@@ -28,6 +28,8 @@ MonoBehaviour:
     m_path: Assets/_Scenes/Level 1.unity
   - m_enabled: 1
     m_path: Assets/_Scenes/Level 2.unity
+  - m_enabled: 1
+    m_path: Assets/_Scenes/GameOverScene.unity
   m_ScriptingDefines: []
   m_PlayerSettingsYaml:
     m_Settings:

--- a/Assets/_Scenes/Level 1.unity
+++ b/Assets/_Scenes/Level 1.unity
@@ -7480,7 +7480,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -349, y: 240}
+  m_AnchoredPosition: {x: 219, y: 175}
   m_SizeDelta: {x: 175, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1976773907

--- a/Assets/_Scenes/Level 2.unity
+++ b/Assets/_Scenes/Level 2.unity
@@ -7561,7 +7561,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 390, y: 240}
+  m_AnchoredPosition: {x: 221, y: 173}
   m_SizeDelta: {x: 175, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1821847137

--- a/Assets/_Scripts/GameManager.cs
+++ b/Assets/_Scripts/GameManager.cs
@@ -71,7 +71,7 @@ public void KillBall()
 
     private IEnumerator GameOverSequence()
     {
-        yield return new WaitForSecondsRealtime(1.5f);
+        yield return new WaitForSecondsRealtime(0.25f);
         SceneManager.LoadScene("GameOverScene");
     }
 

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -14,6 +14,15 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/_Scenes/MainMenu.unity
     guid: 8419faddcbea04d4ba5d31e240e34b03
+  - enabled: 1
+    path: Assets/_Scenes/Level 1.unity
+    guid: 3d838772187c4a9478900baec36c1b6b
+  - enabled: 1
+    path: Assets/_Scenes/Level 2.unity
+    guid: 24dedf98132ebf54e88d2150665b6e55
+  - enabled: 1
+    path: Assets/_Scenes/Level1_ParticleTest.unity
+    guid: 9b0d340ab31aadc4295df6528ed4953c
   m_configObjects:
     com.unity.input.settings.actions: {fileID: -944628639613478452, guid: 052faaac586de48259a63d0c4782560b, type: 3}
   m_UseUCBPForAssetBundles: 0


### PR DESCRIPTION
**Description**  
<!-- Provide a brief description of the changes in this PR. What does it solve or improve? -->  
Fixed overlap issue between Game Over Screen and Score/Lives UI on Level 2 scene. Cleaned up the layout to ensure proper visibility and user experience.


**Type of Change**
<!-- Check the type of change your PR introduces. -->
- [x] Bug fix (non-breaking change that fixes an issue)  
- [ ] Feature (non-breaking change that adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update  

**Checklist**
<!-- Ensure your PR meets the following requirements. -->
- [x] I have tested my changes locally.  
- [ ] I have added tests that prove my fix is effective or my feature works.  
- [x] I have added or updated documentation (if applicable).  
- [x] My changes follow the project's coding style and guidelines.


**Additional Notes**  
- GameOver UI now respects the layout hierarchy properly.  
- Lives and score display no longer interfere on Level 2.  
- Everything has been tested locally in both scenes.
